### PR TITLE
Fix optimization flag for debug builds.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
         .flag_if_supported("-std=c++17")
         .flag_if_supported("/std:c++latest") // For windows
         .flag_if_supported("-pthread")
-        .flag_if_supported("-O 3")
+        .flag_if_supported("-O3")
         .compile("simdjson-sys");
 
     println!("cargo:rerun-if-changed=src/main.rs");


### PR DESCRIPTION
The `-O 3` option when building in the debug profile doesn't seem to have an effect, so simdjson is _very_ slow. In my input of 100k+ json documents, parsing them all takes about 17s. Instead, if I use `-O3` without the space my parsing job takes just 0.6s.

Note that by using `--release` optimizations are turned on, so release binaries don't see a performance hit.