### PR TITLE
Remove main.rs from Cargo build.rs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,6 @@ fn main() {
         .flag_if_supported("-O3")
         .compile("simdjson-sys");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=csrc/wrapper.cpp");
     println!("cargo:rerun-if-changed=csrc/wrapper.h");
 }


### PR DESCRIPTION
The missing main.rs file causes Cargo to always rebuild even if there are no changes to source.