### PR TITLE
Re-enable cache of `target/` dir in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
-            # target/
+            target/
           key: "cache-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}-${{ hashFiles('Cargo.toml') }}-Cpp:${{ matrix.cpp }}"
           restore-keys: |
             "cache-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}-"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 
 
 [dependencies]
-cxx = "1.0.73"
+cxx = "1.0.74"
 thiserror = "1.0"
 # anyhow = "1.0"
 
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
 [build-dependencies]
-cxx-build = "1.0.73"
+cxx-build = "1.0.74"
 
 
 [features]


### PR DESCRIPTION
This PR reverts the last commit of #17 now that the issue affecting Windows in https://github.com/dtolnay/cxx/issues/1085 has been fixed.