### PR TITLE
Use cmake as build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ Cargo.lock
 
 .vscode/
 .idea/
-
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(simdjson_cxx)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(CXXBRIDGE ${CMAKE_CURRENT_SOURCE_DIR}/target/cxxbridge)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  simdjson
+  GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+  GIT_TAG  tags/v3.0.1
+  GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(simdjson)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CXXBRIDGE})
+
+
+add_library(simdjson_cxx SHARED src/simdjson_cxx.cc ${CXXBRIDGE}/simdjson-rust/src/bridge.rs.cc)
+target_link_libraries(simdjson_cxx simdjson)
+
+install(TARGETS simdjson_cxx)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
 [build-dependencies]
+cmake = "0.1.49"
 cxx-build = "1.0.74"
 
 

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,30 @@
+use cmake::Config;
 use cxx_build::CFG;
 use std::env;
 use std::path::Path;
 
 fn main() {
-    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
-    let simdjson_include_dir = Path::new(&manifest_dir).join("csrc").join("simdjson");
-    CFG.exported_header_dirs.push(&simdjson_include_dir);
+    // let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    // let simdjson_include_dir = Path::new(&manifest_dir).join("csrc").join("simdjson");
+    // CFG.exported_header_dirs.push(&simdjson_include_dir);
 
-    cxx_build::bridge("src/libsimdjson.rs") // returns a cc::Build
-        .file("csrc/wrapper.cpp")
-        .file("csrc/simdjson/simdjson.cpp")
-        .flag_if_supported("-std=c++20")
-        .flag_if_supported("/std=c++latest")
-        .flag_if_supported("-pthread")
-        .flag_if_supported("-O3")
-        .compile("simdjson-sys");
+    // cxx_build::bridge("src/libsimdjson.rs") // returns a cc::Build
+    //     .file("csrc/wrapper.cpp")
+    //     .file("csrc/simdjson/simdjson.cpp")
+    //     .flag_if_supported("-std=c++20")
+    //     .flag_if_supported("/std=c++latest")
+    //     .flag_if_supported("-pthread")
+    //     .flag_if_supported("-O3")
+    //     .compile("simdjson-sys");
 
-    println!("cargo:rerun-if-changed=csrc/wrapper.cpp");
-    println!("cargo:rerun-if-changed=csrc/wrapper.h");
+    // println!("cargo:rerun-if-changed=csrc/wrapper.cpp");
+    // println!("cargo:rerun-if-changed=csrc/wrapper.h");
+
+    let _build = cxx_build::bridge("src/bridge.rs");
+
+    let dst = Config::new(".").build().join("lib");
+
+    println!("cargo:rerun-if-changed=src/bridge.rs");
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=simdjson_cxx");
 }

--- a/include/simdjson_cxx.h
+++ b/include/simdjson_cxx.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "rust/cxx.h"
+#include "simdjson.h"
+
+namespace ffi
+{
+    using OndemandParser = simdjson::ondemand::parser;
+
+    int get_int();
+
+    std::unique_ptr<OndemandParser> new_ondemand_parser(size_t max_capacity);
+
+} // namespace ffi

--- a/include/simdjson_cxx.h
+++ b/include/simdjson_cxx.h
@@ -6,9 +6,15 @@
 namespace ffi
 {
     using OndemandParser = simdjson::ondemand::parser;
+    using PaddedString = simdjson::padded_string;
+    using ErrorCode = simdjson::error_code;
+    using OndemandDocument = simdjson::ondemand::document;
 
     int get_int();
 
     std::unique_ptr<OndemandParser> new_ondemand_parser(size_t max_capacity);
+    std::unique_ptr<OndemandDocument> ondemand_parser_iterate(OndemandParser &self, const PaddedString &ps, ErrorCode &code);
+
+    std::unique_ptr<PaddedString> padded_string_load(const std::string &filename, ErrorCode &code);
 
 } // namespace ffi

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,17 +1,102 @@
 #[cxx::bridge(namespace = ffi)]
 pub mod ffi {
 
+    #[derive(Debug)]
+    #[repr(i32)]
+    enum ErrorCode {
+        SUCCESS = 0,
+        ///< No error
+        CAPACITY,
+        ///< This parser can't support a document that big
+        MEMALLOC,
+        ///< Error allocating memory, most likely out of memory
+        TAPE_ERROR,
+        ///< Something went wrong, this is a generic error
+        DEPTH_ERROR,
+        ///< Your document exceeds the user-specified depth limitation
+        STRING_ERROR,
+        ///< Problem while parsing a string
+        T_ATOM_ERROR,
+        ///< Problem while parsing an atom starting with the letter 't'
+        F_ATOM_ERROR,
+        ///< Problem while parsing an atom starting with the letter 'f'
+        N_ATOM_ERROR,
+        ///< Problem while parsing an atom starting with the letter 'n'
+        NUMBER_ERROR,
+        ///< Problem while parsing a number
+        UTF8_ERROR,
+        ///< the input is not valid UTF-8
+        UNINITIALIZED,
+        ///< unknown error, or uninitialized document
+        EMPTY,
+        ///< no structural element found
+        UNESCAPED_CHARS,
+        ///< found unescaped characters in a string.
+        UNCLOSED_STRING,
+        ///< missing quote at the end
+        UNSUPPORTED_ARCHITECTURE,
+        ///< unsupported architecture
+        INCORRECT_TYPE,
+        ///< JSON element has a different type than user expected
+        NUMBER_OUT_OF_RANGE,
+        ///< JSON number does not fit in 64 bits
+        INDEX_OUT_OF_BOUNDS,
+        ///< JSON array index too large
+        NO_SUCH_FIELD,
+        ///< JSON field not found in object
+        IO_ERROR,
+        ///< Error reading a file
+        INVALID_JSON_POINTER,
+        ///< Invalid JSON pointer reference
+        INVALID_URI_FRAGMENT,
+        ///< Invalid URI fragment
+        UNEXPECTED_ERROR,
+        ///< indicative of a bug in simdjson
+        PARSER_IN_USE,
+        ///< parser is already in use.
+        OUT_OF_ORDER_ITERATION,
+        ///< tried to iterate an array or object out of order
+        INSUFFICIENT_PADDING,
+        ///< The JSON doesn't have enough padding for simdjson to safely parse it.
+        INCOMPLETE_ARRAY_OR_OBJECT,
+        ///< The document ends early.
+        SCALAR_DOCUMENT_AS_VALUE,
+        ///< A scalar document is treated as a value.
+        OUT_OF_BOUNDS,
+        ///< Attempted to access location outside of document.
+        TRAILING_CONTENT,
+        ///< Unexpected trailing content in the JSON input
+        NUM_ERROR_CODES,
+    }
+
     unsafe extern "C++" {
         include!("include/simdjson_cxx.h");
+
+        type ErrorCode;
+
         fn get_int() -> i32;
 
         type OndemandParser;
+        type OndemandDocument;
         fn new_ondemand_parser(max_capacity: usize) -> UniquePtr<OndemandParser>;
+        fn ondemand_parser_iterate(
+            p: Pin<&mut OndemandParser>,
+            ps: &PaddedString,
+            code: &mut ErrorCode,
+        ) -> UniquePtr<OndemandDocument>;
+
+        type PaddedString;
+        fn padded_string_load(
+            filename: &CxxString,
+            code: &mut ErrorCode,
+        ) -> UniquePtr<PaddedString>;
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use cxx::let_cxx_string;
+
     use super::*;
 
     #[test]
@@ -22,6 +107,5 @@ mod tests {
     #[test]
     fn new_parser() {
         let parser = ffi::new_ondemand_parser(1024);
-        
     }
 }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,0 +1,27 @@
+#[cxx::bridge(namespace = ffi)]
+pub mod ffi {
+
+    unsafe extern "C++" {
+        include!("include/simdjson_cxx.h");
+        fn get_int() -> i32;
+
+        type OndemandParser;
+        fn new_ondemand_parser(max_capacity: usize) -> UniquePtr<OndemandParser>;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(ffi::get_int(), 1);
+    }
+
+    #[test]
+    fn new_parser() {
+        let parser = ffi::new_ondemand_parser(1024);
+        
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub const SIMDJSON_MAXSIZE_BYTES: usize = 0xFFFFFFFF;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,19 @@
-use serde::de;
-use std::fmt::Display;
-
 use thiserror::Error;
 
-pub type SimdJsonResult<T> = Result<T, SimdJsonError>;
+pub type Result<T> = std::result::Result<T, SimdJsonError>;
+use crate::bridge::ffi::ErrorCode;
+
+
 
 #[derive(Debug, Error)]
 pub enum SimdJsonError {
-    #[error("Message: {0}")]
-    Message(String),
-
     #[error("This parser can't support a document that big")]
     Capacity,
 
     #[error("Error allocating memory, we're most likely out of memory")]
-    MemAlloc,
+    Memalloc,
 
-    #[error("Something went wrong while writing to the tape")]
+    #[error("The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc.")]
     TapeError,
 
     #[error("The JSON document was too deep (too many nested objects and arrays)")]
@@ -80,46 +77,64 @@ pub enum SimdJsonError {
         "Unexpected error, consider reporting this problem as you may have found a bug in simdjson"
     )]
     UnexpectedError,
+
+    #[error("todo")]
+    ParserInUse,
+
+    #[error("todo")]
+    OutOfOrderIteration,
+
+    #[error("todo")]
+    InsufficientPadding,
+
+    #[error("todo")]
+    IncompleteArrayOrObject,
+
+    #[error("todo")]
+    ScalarDocumentAsValue,
+
+    #[error("todo")]
+    OutOfBounds,
+
+    #[error("todo")]
+    TrailingContent,
 }
 
-impl From<i32> for SimdJsonError {
-    fn from(error_code: i32) -> Self {
+impl From<ErrorCode> for SimdJsonError {
+    fn from(error_code: ErrorCode) -> Self {
         match error_code {
-            0 => panic!("No error"),
-            1 => panic!("No error and buffer still has more data"),
-            2 => SimdJsonError::Capacity,
-            3 => SimdJsonError::MemAlloc,
-            4 => SimdJsonError::TapeError,
-            5 => SimdJsonError::DepthError,
-            6 => SimdJsonError::StringError,
-            7 => SimdJsonError::TAtomError,
-            8 => SimdJsonError::FAtomError,
-            9 => SimdJsonError::NAtomError,
-            10 => SimdJsonError::NumberError,
-            11 => SimdJsonError::Utf8Error,
-            12 => SimdJsonError::Uninitialized,
-            13 => SimdJsonError::Empty,
-            14 => SimdJsonError::UnescapedChars,
-            15 => SimdJsonError::UnclosedString,
-            16 => SimdJsonError::UnsupportedArchitecture,
-            17 => SimdJsonError::IncorrectType,
-            18 => SimdJsonError::NumberOutOfRange,
-            19 => SimdJsonError::IndexOutOfBounds,
-            20 => SimdJsonError::NoSuchField,
-            21 => SimdJsonError::IoError,
-            22 => SimdJsonError::InvalidJsonPointer,
-            23 => SimdJsonError::InvalidUriFragment,
-            24 => SimdJsonError::UnexpectedError,
-            x => panic!("Unknown error code: {}", x),
+            ErrorCode::SUCCESS => panic!("No error"),
+            ErrorCode::CAPACITY => Self::Capacity,
+            ErrorCode::MEMALLOC => Self::Memalloc,
+            ErrorCode::TAPE_ERROR => Self::TapeError,
+            ErrorCode::DEPTH_ERROR => Self::DepthError,
+            ErrorCode::STRING_ERROR => Self::StringError,
+            ErrorCode::T_ATOM_ERROR => Self::TAtomError,
+            ErrorCode::F_ATOM_ERROR => Self::FAtomError,
+            ErrorCode::N_ATOM_ERROR => Self::NAtomError,
+            ErrorCode::NUMBER_ERROR => Self::NumberError,
+            ErrorCode::UTF8_ERROR => Self::Utf8Error,
+            ErrorCode::UNINITIALIZED => Self::Uninitialized,
+            ErrorCode::EMPTY => Self::Empty,
+            ErrorCode::UNESCAPED_CHARS => Self::UnescapedChars,
+            ErrorCode::UNCLOSED_STRING => Self::UnclosedString,
+            ErrorCode::UNSUPPORTED_ARCHITECTURE => Self::UnsupportedArchitecture,
+            ErrorCode::INCORRECT_TYPE => Self::IncorrectType,
+            ErrorCode::NUMBER_OUT_OF_RANGE => Self::NumberOutOfRange,
+            ErrorCode::INDEX_OUT_OF_BOUNDS => Self::IndexOutOfBounds,
+            ErrorCode::NO_SUCH_FIELD => Self::NoSuchField,
+            ErrorCode::IO_ERROR => Self::IoError,
+            ErrorCode::INVALID_JSON_POINTER => Self::InvalidJsonPointer,
+            ErrorCode::INVALID_URI_FRAGMENT => Self::InvalidUriFragment,
+            ErrorCode::UNEXPECTED_ERROR => Self::UnexpectedError,
+            ErrorCode::PARSER_IN_USE => Self::ParserInUse,
+            ErrorCode::OUT_OF_ORDER_ITERATION => Self::OutOfOrderIteration,
+            ErrorCode::INSUFFICIENT_PADDING => Self::InsufficientPadding,
+            ErrorCode::INCOMPLETE_ARRAY_OR_OBJECT => Self::IncompleteArrayOrObject,
+            ErrorCode::SCALAR_DOCUMENT_AS_VALUE => Self::ScalarDocumentAsValue,
+            ErrorCode::OUT_OF_BOUNDS => Self::OutOfBounds,
+            ErrorCode::TRAILING_CONTENT => Self::TrailingContent,
+            x => panic!("Unknown error code: {:?}", x),
         }
-    }
-}
-
-impl de::Error for SimdJsonError {
-    fn custom<T>(msg: T) -> Self
-    where
-        T: Display,
-    {
-        Self::Message(msg.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,12 @@
 // pub use parsed_json::{ParsedJson, DEFUALT_MAX_DEPTH};
 // pub use parsed_json_iterator::ParsedJsonIterator;
 
-pub mod dom;
-pub mod error;
-pub mod libsimdjson;
-pub mod padded_string;
-pub mod serde;
+// pub mod dom;
+// pub mod error;
+// pub mod libsimdjson;
+// pub mod padded_string;
+// pub mod serde;
+pub mod bridge;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,13 @@
 // pub use parsed_json_iterator::ParsedJsonIterator;
 
 // pub mod dom;
-// pub mod error;
+pub mod error;
 // pub mod libsimdjson;
-// pub mod padded_string;
+pub mod padded_string;
 // pub mod serde;
 pub mod bridge;
+pub mod ondemand;
+pub mod constants;
 
 #[cfg(test)]
 mod tests {

--- a/src/ondemand/document.rs
+++ b/src/ondemand/document.rs
@@ -1,0 +1,15 @@
+use std::fmt::Debug;
+
+use cxx::UniquePtr;
+
+use crate::bridge::ffi;
+
+pub struct Document(pub UniquePtr<ffi::OndemandDocument>);
+
+impl Document {}
+
+impl Debug for Document {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Document").finish()
+    }
+}

--- a/src/ondemand/mod.rs
+++ b/src/ondemand/mod.rs
@@ -1,0 +1,2 @@
+pub mod parser;
+pub mod document;

--- a/src/ondemand/parser.rs
+++ b/src/ondemand/parser.rs
@@ -1,0 +1,56 @@
+use std::fmt::Debug;
+
+use cxx::UniquePtr;
+
+use crate::{
+    bridge::ffi::{self, ErrorCode},
+    constants::SIMDJSON_MAXSIZE_BYTES,
+    error::Result,
+    padded_string::PaddedString,
+};
+
+use super::document::Document;
+
+pub struct Parser(UniquePtr<ffi::OndemandParser>);
+
+impl Parser {
+    pub fn new(max_capacity: usize) -> Self {
+        Self(ffi::new_ondemand_parser(max_capacity))
+    }
+
+    pub fn iterate(&mut self, padded_string: &PaddedString) -> Result<Document> {
+        let mut code = ErrorCode::SUCCESS;
+        let doc = ffi::ondemand_parser_iterate(self.0.pin_mut(), &padded_string, &mut code);
+        if code == ErrorCode::SUCCESS {
+            Ok(Document(doc))
+        } else {
+            Err(code.into())
+        }
+    }
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new(SIMDJSON_MAXSIZE_BYTES)
+    }
+}
+
+impl Debug for Parser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parser").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_parser() {
+        let mut parser = Parser::default();
+        let ps = PaddedString::load("json-examples/twitter.json").unwrap();
+        let doc = parser.iterate(&ps);
+        dbg!(&doc);
+        assert!(doc.is_ok());
+    }
+}

--- a/src/padded_string.rs
+++ b/src/padded_string.rs
@@ -1,24 +1,82 @@
-use super::libsimdjson::ffi;
+// use super::libsimdjson::ffi;
 
-pub type PaddedStringPtr = cxx::UniquePtr<ffi::padded_string>;
+// pub type PaddedStringPtr = cxx::UniquePtr<ffi::padded_string>;
 
-pub struct PaddedString {
-    ptr: PaddedStringPtr,
-}
+// pub struct PaddedString {
+//     ptr: PaddedStringPtr,
+// }
+
+// impl PaddedString {
+//     pub fn new(ptr: PaddedStringPtr) -> Self {
+//         PaddedString { ptr }
+//     }
+
+//     pub fn as_ptr(&self) -> &PaddedStringPtr {
+//         &self.ptr
+//     }
+// }
+
+// impl From<&str> for PaddedString {
+//     fn from(s: &str) -> Self {
+//         let ptr = ffi::padded_string_from_string(s);
+//         PaddedString { ptr }
+//     }
+// }
+
+use std::{fmt::Debug, ops::Deref, os::unix::prelude::OsStrExt, path::Path};
+
+use cxx::{let_cxx_string, UniquePtr};
+
+use crate::{
+    bridge::ffi::{self, ErrorCode},
+    error::Result,
+};
+
+pub struct PaddedString(UniquePtr<ffi::PaddedString>);
 
 impl PaddedString {
-    pub fn new(ptr: PaddedStringPtr) -> Self {
-        PaddedString { ptr }
-    }
-
-    pub fn as_ptr(&self) -> &PaddedStringPtr {
-        &self.ptr
+    pub fn load<P>(filename: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let mut code = ErrorCode::SUCCESS;
+        let_cxx_string!(filename_cxx = filename.as_ref().as_os_str().as_bytes());
+        let ps = ffi::padded_string_load(&filename_cxx, &mut code);
+        if code == ErrorCode::SUCCESS {
+            Ok(Self(ps))
+        } else {
+            Err(code.into())
+        }
     }
 }
 
-impl From<&str> for PaddedString {
-    fn from(s: &str) -> Self {
-        let ptr = ffi::padded_string_from_string(s);
-        PaddedString { ptr }
+impl Debug for PaddedString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PaddedString").finish()
+    }
+}
+
+impl Deref for PaddedString {
+    type Target = UniquePtr<ffi::PaddedString>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::error::SimdJsonError;
+
+    use super::*;
+
+    #[test]
+    fn load_padded_string() {
+        let ps = PaddedString::load("json-examples/twitter.json");
+        assert!(ps.is_ok());
+
+        let ps = PaddedString::load("asdf");
+        assert!(ps.is_err());
     }
 }

--- a/src/simdjson_cxx.cc
+++ b/src/simdjson_cxx.cc
@@ -1,0 +1,14 @@
+#include "include/simdjson_cxx.h"
+
+namespace ffi
+{
+    int get_int()
+    {
+        return 1;
+    }
+
+    std::unique_ptr<OndemandParser> new_ondemand_parser(size_t max_capacity)
+    {
+        return std::make_unique<OndemandParser>(max_capacity);
+    }
+} // namespace ffi

--- a/src/simdjson_cxx.cc
+++ b/src/simdjson_cxx.cc
@@ -11,4 +11,19 @@ namespace ffi
     {
         return std::make_unique<OndemandParser>(max_capacity);
     }
+
+    std::unique_ptr<OndemandDocument> ondemand_parser_iterate(OndemandParser &p, const PaddedString &ps, ErrorCode &code)
+    {
+        OndemandDocument doc;
+        p.iterate(ps).tie(doc, code);
+        return std::make_unique<OndemandDocument>(std::move(doc));
+    }
+
+    std::unique_ptr<PaddedString> padded_string_load(const std::string &filename, ErrorCode &code)
+    {
+        PaddedString ps;
+        PaddedString::load(filename).tie(ps, code);
+        return std::make_unique<PaddedString>(std::move(ps));
+    }
+
 } // namespace ffi


### PR DESCRIPTION
I decided to switch to `cmake` since it is better supported by simdjson.
We will bind latest v3.0.1 and write new ffi code.
This pr may fix #20 .

Roadmap:
- [x] `padded_string`
- [x] `simdjson::ondemand::parser`
- [x] `simdjson::ondemand::document`
- [ ] `Debug` trait for most structs